### PR TITLE
`FolderCreator` 依存関係の削除とメタデータ追加

### DIFF
--- a/Packages/FolderCreator.meta
+++ b/Packages/FolderCreator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6bf9f57f5ae39145899a823b16989c2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,11 +1,5 @@
 {
   "dependencies": {
-    "com.kenmasamaki.foldercreator": {
-      "version": "file:FolderCreator",
-      "depth": 0,
-      "source": "embedded",
-      "dependencies": {}
-    },
     "com.unity.collab-proxy": {
       "version": "2.8.2",
       "depth": 0,


### PR DESCRIPTION
`packages-lock.json` から `com.kenmasamaki.foldercreator` の依存関係を削除しました。これにより、`FolderCreator` のローカルファイルバージョンがプロジェクトから除外されました。

また、`FolderCreator.meta` に新しいメタデータを追加し、ファイルフォーマットバージョン、GUID、フォルダーアセットの有無、デフォルトインポーターの設定を含めました。これにより、`FolderCreator` アセットの管理が改善されます。